### PR TITLE
Example of user defined config table view for interfaces

### DIFF
--- a/InterfaceConfigTable.yml
+++ b/InterfaceConfigTable.yml
@@ -1,0 +1,35 @@
+# Following table view will let you get configuration data about interfaces from a Juniper Switch.
+# For a given interface it will let you query 
+#  - if mode is trunk or access
+#  - What is its native vlan
+#  - What vlans are members of its configuration
+#  - Whether it is enabled or disabled
+#  - What are its logical interfaces.
+#  More can be added as necessary.
+# Created to be used for writing a Juniper driver for HIL: https://github.com/CCI-MOC/hil
+---
+InterfaceConfigTable:
+  get: interfaces/interface
+  required_keys: 
+    interface: name
+  view: InterfaceConfigView
+InterfaceConfigView:
+  fields:
+    interface_name: name
+    logical_interface: unit/name
+    trunk_mode: { unit/family/ethernet-switching/interface-mode : True=regex(trunk) }
+    vlans: unit/family/ethernet-switching/vlan/members
+    native_vlan: native-vlan-id
+
+# Usage: After opening a session to the switch as 'dev'
+# do the following:
+# Save the above yaml file into file in directory config_tables.
+# from config_tables.InterfaceConfigTable import InterfaceConfigTable
+# ic = InterfaceConfigTable(dev)
+# ic.get(interface= 'et-0/0/11', options = {'database':'committed'})
+# ic.items() ## Will give you tuples
+# ic.to_json() ## Will give you a json string that can be converted to dict.
+#
+# REFERENCES:
+# https://www.juniper.net/documentation/en_US/junos-pyez/topics/task/program/junos-pyez-tables-config-defining.html
+# https://www.juniper.net/documentation/en_US/junos-pyez/topics/task/program/junos-pyez-tables-config-data-retrieving-manipulating.html


### PR DESCRIPTION
Contributing a user defined table to gather configuration information from interfaces of junos devices. 